### PR TITLE
feat: add agent selection and MindWorks API skeleton

### DIFF
--- a/lib/Constants/app_constants.dart
+++ b/lib/Constants/app_constants.dart
@@ -1,5 +1,5 @@
 class AppConstants {
-  static const String appName = 'Reins';
+  static const String appName = 'MindWorks Mobile';
   static const String appIconPng = 'assets/images/reins.png';
   static const String appIconSvg = 'assets/images/reins.svg';
 

--- a/lib/Models/mindworks_message.dart
+++ b/lib/Models/mindworks_message.dart
@@ -1,0 +1,33 @@
+class MindWorksMessage {
+  MindWorksMessage({
+    required this.role,
+    required this.content,
+    DateTime? timestamp,
+  }) : timestamp = timestamp ?? DateTime.now();
+
+  final String role;
+  final String content;
+  final DateTime timestamp;
+}
+
+class MindWorksDebugEntry {
+  MindWorksDebugEntry({
+    required this.prompt,
+    required this.response,
+    required this.rawResponse,
+    required this.statusCode,
+    required this.duration,
+    this.errorMessage,
+    DateTime? timestamp,
+  }) : timestamp = timestamp ?? DateTime.now();
+
+  final String prompt;
+  final String response;
+  final String rawResponse;
+  final int statusCode;
+  final Duration duration;
+  final String? errorMessage;
+  final DateTime timestamp;
+
+  bool get isError => errorMessage != null || statusCode < 200 || statusCode >= 300;
+}

--- a/lib/Pages/main_page.dart
+++ b/lib/Pages/main_page.dart
@@ -4,8 +4,8 @@ import 'package:reins/Widgets/chat_app_bar.dart';
 import 'package:reins/Widgets/chat_drawer.dart';
 import 'package:responsive_framework/responsive_framework.dart';
 
-class ReinsMainPage extends StatelessWidget {
-  const ReinsMainPage({super.key});
+class MindWorksMainPage extends StatelessWidget {
+  const MindWorksMainPage({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -16,13 +16,13 @@ class ReinsMainPage extends StatelessWidget {
         drawer: ChatDrawer(),
       );
     } else {
-      return _ReinsLargeMainPage();
+      return _MindWorksLargeMainPage();
     }
   }
 }
 
-class _ReinsLargeMainPage extends StatelessWidget {
-  const _ReinsLargeMainPage({super.key});
+class _MindWorksLargeMainPage extends StatelessWidget {
+  const _MindWorksLargeMainPage({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/Pages/main_page.dart
+++ b/lib/Pages/main_page.dart
@@ -1,40 +1,11 @@
 import 'package:flutter/material.dart';
-import 'package:reins/Pages/chat_page/chat_page.dart';
-import 'package:reins/Widgets/chat_app_bar.dart';
-import 'package:reins/Widgets/chat_drawer.dart';
-import 'package:responsive_framework/responsive_framework.dart';
+import 'package:reins/Pages/mindworks_chat_page.dart';
 
 class MindWorksMainPage extends StatelessWidget {
   const MindWorksMainPage({super.key});
 
   @override
   Widget build(BuildContext context) {
-    if (ResponsiveBreakpoints.of(context).isMobile) {
-      return const Scaffold(
-        appBar: ChatAppBar(),
-        body: SafeArea(child: ChatPage()),
-        drawer: ChatDrawer(),
-      );
-    } else {
-      return _MindWorksLargeMainPage();
-    }
-  }
-}
-
-class _MindWorksLargeMainPage extends StatelessWidget {
-  const _MindWorksLargeMainPage({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return const Scaffold(
-      body: SafeArea(
-        child: Row(
-          children: [
-            ChatDrawer(),
-            Expanded(child: ChatPage()),
-          ],
-        ),
-      ),
-    );
+    return const MindWorksChatPage();
   }
 }

--- a/lib/Pages/mindworks_chat_page.dart
+++ b/lib/Pages/mindworks_chat_page.dart
@@ -1,0 +1,398 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:provider/provider.dart';
+import 'package:reins/Constants/app_constants.dart';
+import 'package:reins/Models/mindworks_message.dart';
+import 'package:reins/Providers/agent_provider.dart';
+import 'package:reins/Providers/mindworks_chat_provider.dart';
+import 'package:reins/Widgets/agent_selector.dart';
+
+class MindWorksChatPage extends StatefulWidget {
+  const MindWorksChatPage({super.key});
+
+  @override
+  State<MindWorksChatPage> createState() => _MindWorksChatPageState();
+}
+
+class _MindWorksChatPageState extends State<MindWorksChatPage> {
+  final TextEditingController _promptController = TextEditingController();
+  final TextEditingController _sessionTagController = TextEditingController();
+  final ScrollController _scrollController = ScrollController();
+  int _lastMessageCount = 0;
+
+  static const List<String> _defaultAgents = <String>['MIRA', 'Keeper', 'Analytica', 'AURA'];
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final provider = context.read<MindWorksChatProvider>();
+      _sessionTagController.text = provider.sessionTag;
+    });
+    _sessionTagController.addListener(() {
+      context.read<MindWorksChatProvider>().updateSessionTag(_sessionTagController.text);
+    });
+  }
+
+  @override
+  void dispose() {
+    _promptController.dispose();
+    _sessionTagController.dispose();
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final agentProvider = context.watch<AgentProvider>();
+    final chatProvider = context.watch<MindWorksChatProvider>();
+    final lastStatus = chatProvider.lastStatus;
+    final errorMessage = chatProvider.errorMessage;
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(AppConstants.appName),
+        actions: [
+          IconButton(
+            tooltip: 'Clear conversation',
+            icon: const Icon(Icons.delete_sweep_outlined),
+            onPressed: () => context.read<MindWorksChatProvider>().clearConversation(),
+          ),
+        ],
+      ),
+      body: SafeArea(
+        child: Column(
+          children: [
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Wrap(
+                    spacing: 12,
+                    runSpacing: 12,
+                    crossAxisAlignment: WrapCrossAlignment.center,
+                    children: [
+                      AgentSelector(agents: _defaultAgents),
+                      _PersonaDropdown(personas: chatProvider.personas),
+                      Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Switch(
+                            value: agentProvider.logToMemory,
+                            onChanged: (value) => context.read<MindWorksChatProvider>().toggleLogToMemory(value),
+                          ),
+                          const SizedBox(width: 8),
+                          const Text('Log to memory'),
+                        ],
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 12),
+                  TextField(
+                    controller: _sessionTagController,
+                    decoration: const InputDecoration(
+                      labelText: 'Session tag',
+                      hintText: 'e.g. onboarding-session-01',
+                      border: OutlineInputBorder(),
+                    ),
+                  ),
+                  if (lastStatus != null)
+                    Padding(
+                      padding: const EdgeInsets.only(top: 8),
+                      child: _ApiStatusChip(entry: lastStatus),
+                    ),
+                  if (errorMessage != null)
+                    Padding(
+                      padding: const EdgeInsets.only(top: 8),
+                      child: Text(
+                        errorMessage,
+                        style: TextStyle(color: Theme.of(context).colorScheme.error),
+                      ),
+                    ),
+                ],
+              ),
+            ),
+            const Divider(height: 1),
+            Expanded(
+              child: Consumer<MindWorksChatProvider>(
+                builder: (context, provider, _) {
+                  if (_lastMessageCount != provider.messages.length) {
+                    _lastMessageCount = provider.messages.length;
+                    WidgetsBinding.instance.addPostFrameCallback((_) => _scrollToBottom());
+                  }
+                  if (provider.messages.isEmpty) {
+                    return const _EmptyState();
+                  }
+                  return ListView.builder(
+                    controller: _scrollController,
+                    padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                    itemCount: provider.messages.length,
+                    itemBuilder: (context, index) {
+                      final message = provider.messages[index];
+                      return _MessageBubble(message: message);
+                    },
+                  );
+                },
+              ),
+            ),
+            const Divider(height: 1),
+            _PromptComposer(
+              controller: _promptController,
+              onSend: _handleSend,
+            ),
+            const Divider(height: 1),
+            const _DebugPanel(),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _handleSend() async {
+    final text = _promptController.text.trim();
+    if (text.isEmpty) return;
+    final chatProvider = context.read<MindWorksChatProvider>();
+    await chatProvider.sendPrompt(text);
+    if (mounted) {
+      _promptController.clear();
+    }
+  }
+
+  void _scrollToBottom() {
+    if (!_scrollController.hasClients) return;
+    _scrollController.animateTo(
+      _scrollController.position.maxScrollExtent,
+      duration: const Duration(milliseconds: 250),
+      curve: Curves.easeOut,
+    );
+  }
+}
+
+class _PersonaDropdown extends StatelessWidget {
+  const _PersonaDropdown({required this.personas});
+
+  final List<String> personas;
+
+  @override
+  Widget build(BuildContext context) {
+    final agentProvider = context.watch<AgentProvider>();
+    return DropdownButton<String?>(
+      value: agentProvider.persona,
+      hint: const Text('Persona'),
+      items: [
+        const DropdownMenuItem<String?>(value: null, child: Text('Default persona')),
+        ...personas.map(
+          (persona) => DropdownMenuItem<String?>(
+            value: persona,
+            child: Text(persona),
+          ),
+        ),
+      ],
+      onChanged: (value) => context.read<MindWorksChatProvider>().setPersona(value),
+    );
+  }
+}
+
+class _PromptComposer extends StatelessWidget {
+  const _PromptComposer({required this.controller, required this.onSend});
+
+  final TextEditingController controller;
+  final Future<void> Function() onSend;
+
+  @override
+  Widget build(BuildContext context) {
+    final isSending = context.watch<MindWorksChatProvider>().isSending;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+      child: Row(
+        children: [
+          Expanded(
+            child: TextField(
+              controller: controller,
+              maxLines: null,
+              decoration: const InputDecoration(
+                hintText: 'Ask MindWorks…',
+                border: OutlineInputBorder(),
+              ),
+              onSubmitted: (_) => onSend(),
+            ),
+          ),
+          const SizedBox(width: 12),
+          ElevatedButton.icon(
+            onPressed: isSending ? null : () => onSend(),
+            icon: isSending
+                ? const SizedBox(
+                    width: 16,
+                    height: 16,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Icon(Icons.send),
+            label: Text(isSending ? 'Sending…' : 'Send'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _MessageBubble extends StatelessWidget {
+  const _MessageBubble({required this.message});
+
+  final MindWorksMessage message;
+
+  @override
+  Widget build(BuildContext context) {
+    final isUser = message.role == 'user';
+    final alignment = isUser ? CrossAxisAlignment.end : CrossAxisAlignment.start;
+    final colorScheme = Theme.of(context).colorScheme;
+    final backgroundColor = isUser
+        ? colorScheme.primaryContainer
+        : colorScheme.surfaceVariant;
+    final textColor = isUser ? colorScheme.onPrimaryContainer : colorScheme.onSurfaceVariant;
+
+    return Align(
+      alignment: isUser ? Alignment.centerRight : Alignment.centerLeft,
+      child: Container(
+        margin: const EdgeInsets.symmetric(vertical: 6),
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        constraints: BoxConstraints(maxWidth: MediaQuery.of(context).size.width * 0.8),
+        decoration: BoxDecoration(
+          color: backgroundColor,
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: Column(
+          crossAxisAlignment: alignment,
+          children: [
+            Text(
+              isUser ? 'You' : 'MindWorks',
+              style: Theme.of(context).textTheme.labelSmall?.copyWith(color: textColor.withOpacity(0.8)),
+            ),
+            const SizedBox(height: 4),
+            if (isUser)
+              Text(
+                message.content,
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(color: textColor),
+              )
+            else
+              MarkdownBody(
+                data: message.content,
+                selectable: true,
+                styleSheet: MarkdownStyleSheet.fromTheme(Theme.of(context)).copyWith(
+                  p: Theme.of(context).textTheme.bodyMedium?.copyWith(color: textColor),
+                  code: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        color: textColor,
+                        fontFamily: 'monospace',
+                      ),
+                  h1: Theme.of(context).textTheme.titleLarge?.copyWith(color: textColor, fontWeight: FontWeight.bold),
+                  h2: Theme.of(context).textTheme.titleMedium?.copyWith(color: textColor, fontWeight: FontWeight.bold),
+                  h3: Theme.of(context).textTheme.titleSmall?.copyWith(color: textColor, fontWeight: FontWeight.bold),
+                  listBullet: TextStyle(color: textColor),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _EmptyState extends StatelessWidget {
+  const _EmptyState();
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: const [
+          Icon(Icons.psychology_alt_outlined, size: 48),
+          SizedBox(height: 12),
+          Text('Start a conversation with your MindWorks agents'),
+        ],
+      ),
+    );
+  }
+}
+
+class _DebugPanel extends StatelessWidget {
+  const _DebugPanel();
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<MindWorksChatProvider>(
+      builder: (context, provider, _) {
+        return ExpansionTile(
+          title: const Text('Debug panel'),
+          subtitle: Text(
+            provider.debugEntries.isEmpty
+                ? 'No logs yet'
+                : 'Showing ${provider.debugEntries.length} recent interactions',
+          ),
+          children: [
+            if (provider.debugEntries.isEmpty)
+              const Padding(
+                padding: EdgeInsets.all(16),
+                child: Text('Interact with MindWorks to see request logs here.'),
+              )
+            else
+              SizedBox(
+                height: 240,
+                child: ListView.builder(
+                  itemCount: provider.debugEntries.length,
+                  itemBuilder: (context, index) {
+                    final entry = provider.debugEntries[index];
+                    return ListTile(
+                      title: Text(entry.prompt),
+                      subtitle: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text('Status: ${entry.statusCode} • ${entry.duration.inMilliseconds} ms'),
+                          if (entry.isError && entry.errorMessage != null)
+                            Text(
+                              entry.errorMessage!,
+                              style: TextStyle(color: Theme.of(context).colorScheme.error),
+                            ),
+                          const SizedBox(height: 4),
+                          SelectableText('Response: ${entry.response}'),
+                          const SizedBox(height: 4),
+                          SelectableText('Raw: ${entry.rawResponse}'),
+                        ],
+                      ),
+                      trailing: Text(
+                        TimeOfDay.fromDateTime(entry.timestamp).format(context),
+                        style: Theme.of(context).textTheme.bodySmall,
+                      ),
+                    );
+                  },
+                ),
+              ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _ApiStatusChip extends StatelessWidget {
+  const _ApiStatusChip({required this.entry});
+
+  final MindWorksDebugEntry entry;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final isError = entry.isError;
+    final color = isError ? colorScheme.errorContainer : colorScheme.secondaryContainer;
+    final textColor = isError ? colorScheme.onErrorContainer : colorScheme.onSecondaryContainer;
+
+    return Chip(
+      backgroundColor: color,
+      label: Text(
+        isError
+            ? 'API error ${entry.statusCode}'
+            : 'API ${entry.statusCode} • ${entry.duration.inMilliseconds} ms',
+        style: TextStyle(color: textColor),
+      ),
+    );
+  }
+}

--- a/lib/Providers/agent_provider.dart
+++ b/lib/Providers/agent_provider.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/foundation.dart';
+import 'package:hive/hive.dart';
+
+/// Provides state for the currently selected MindWorks agent,
+/// persona preset, and memory logging flag.
+class AgentProvider with ChangeNotifier {
+  AgentProvider() {
+    final box = Hive.box('settings');
+    _selectedAgent = box.get('agent', defaultValue: _selectedAgent);
+    _persona = box.get('persona');
+    _logToMemory = box.get('logToMemory', defaultValue: false);
+  }
+
+  String _selectedAgent = 'MIRA';
+  String? _persona;
+  bool _logToMemory = false;
+
+  String get selectedAgent => _selectedAgent;
+  String? get persona => _persona;
+  bool get logToMemory => _logToMemory;
+
+  void selectAgent(String agent) {
+    _selectedAgent = agent;
+    Hive.box('settings').put('agent', agent);
+    notifyListeners();
+  }
+
+  void selectPersona(String? persona) {
+    _persona = persona;
+    Hive.box('settings').put('persona', persona);
+    notifyListeners();
+  }
+
+  void toggleLogToMemory(bool value) {
+    _logToMemory = value;
+    Hive.box('settings').put('logToMemory', value);
+    notifyListeners();
+  }
+}

--- a/lib/Providers/mindworks_chat_provider.dart
+++ b/lib/Providers/mindworks_chat_provider.dart
@@ -1,0 +1,190 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:reins/Models/mindworks_message.dart';
+import 'package:reins/Providers/agent_provider.dart';
+import 'package:reins/Services/mindworks_service.dart';
+
+class MindWorksChatProvider extends ChangeNotifier {
+  MindWorksChatProvider({
+    required MindWorksService service,
+    required AgentProvider agentProvider,
+  })  : _service = service,
+        _agentProvider = agentProvider {
+    _sessionTag = Hive.box('settings').get('sessionTag', defaultValue: '') as String;
+  }
+
+  final MindWorksService _service;
+  final AgentProvider _agentProvider;
+
+  final List<MindWorksMessage> _messages = <MindWorksMessage>[];
+  List<MindWorksMessage> get messages => List.unmodifiable(_messages);
+
+  final List<MindWorksDebugEntry> _debugEntries = <MindWorksDebugEntry>[];
+  List<MindWorksDebugEntry> get debugEntries => List.unmodifiable(_debugEntries);
+
+  MindWorksDebugEntry? _lastStatus;
+  MindWorksDebugEntry? get lastStatus => _lastStatus;
+
+  bool _isSending = false;
+  bool get isSending => _isSending;
+
+  String? _errorMessage;
+  String? get errorMessage => _errorMessage;
+
+  String _sessionTag = '';
+  String get sessionTag => _sessionTag;
+
+  Timer? _statusResetTimer;
+  Timer? _sessionTagDebounce;
+
+  final List<String> personas = const <String>['Reflective', 'Teacher', 'Analyst'];
+
+  Future<void> sendPrompt(String prompt) async {
+    final trimmedPrompt = prompt.trim();
+    if (trimmedPrompt.isEmpty || _isSending) {
+      return;
+    }
+
+    _setError(null);
+    _isSending = true;
+    notifyListeners();
+
+    final userMessage = MindWorksMessage(role: 'user', content: trimmedPrompt);
+    _messages.add(userMessage);
+    notifyListeners();
+
+    try {
+      final result = await _service.sendPrompt(
+        agent: _agentProvider.selectedAgent,
+        prompt: trimmedPrompt,
+        persona: _agentProvider.persona,
+        logToMemory: _agentProvider.logToMemory,
+        sessionTag: _sessionTag.isEmpty ? null : _sessionTag,
+      );
+
+      final responseText = _extractResponseText(result.body, result.rawBody);
+      final assistantMessage = MindWorksMessage(role: 'assistant', content: responseText);
+      _messages.add(assistantMessage);
+
+      _registerDebugEntry(
+        prompt: trimmedPrompt,
+        response: responseText,
+        rawResponse: result.rawBody,
+        statusCode: result.statusCode,
+        duration: result.duration,
+      );
+    } on MindWorksApiException catch (error) {
+      _registerDebugEntry(
+        prompt: trimmedPrompt,
+        response: error.result.body.toString(),
+        rawResponse: error.result.rawBody,
+        statusCode: error.result.statusCode,
+        duration: error.result.duration,
+        errorMessage: error.message,
+      );
+      _setError(error.message ?? 'MindWorks request failed.');
+    } catch (error) {
+      _registerDebugEntry(
+        prompt: trimmedPrompt,
+        response: error.toString(),
+        rawResponse: error.toString(),
+        statusCode: -1,
+        duration: Duration.zero,
+        errorMessage: error.toString(),
+      );
+      _setError('Unexpected error: $error');
+    } finally {
+      _isSending = false;
+      notifyListeners();
+    }
+  }
+
+  void clearConversation() {
+    _messages.clear();
+    _errorMessage = null;
+    _lastStatus = null;
+    _statusResetTimer?.cancel();
+    _statusResetTimer = null;
+    notifyListeners();
+  }
+
+  void updateSessionTag(String value) {
+    _sessionTag = value;
+    _sessionTagDebounce?.cancel();
+    _sessionTagDebounce = Timer(const Duration(milliseconds: 400), () {
+      Hive.box('settings').put('sessionTag', value);
+    });
+    notifyListeners();
+  }
+
+  void setPersona(String? persona) {
+    _agentProvider.selectPersona(persona);
+  }
+
+  void toggleLogToMemory(bool value) {
+    _agentProvider.toggleLogToMemory(value);
+  }
+
+  void _registerDebugEntry({
+    required String prompt,
+    required String response,
+    required String rawResponse,
+    required int statusCode,
+    required Duration duration,
+    String? errorMessage,
+  }) {
+    final entry = MindWorksDebugEntry(
+      prompt: prompt,
+      response: response,
+      rawResponse: rawResponse,
+      statusCode: statusCode,
+      duration: duration,
+      errorMessage: errorMessage,
+    );
+
+    _debugEntries.insert(0, entry);
+    if (_debugEntries.length > 10) {
+      _debugEntries.removeLast();
+    }
+
+    _lastStatus = entry;
+    notifyListeners();
+
+    _statusResetTimer?.cancel();
+    _statusResetTimer = Timer(const Duration(seconds: 10), () {
+      _lastStatus = null;
+      notifyListeners();
+    });
+  }
+
+  String _extractResponseText(Map<String, dynamic> body, String rawBody) {
+    final possibleKeys = ['response', 'text', 'output', 'message', 'content'];
+    for (final key in possibleKeys) {
+      final value = body[key];
+      if (value is String && value.trim().isNotEmpty) {
+        return value;
+      }
+      if (value is Map<String, dynamic>) {
+        final nested = value['text'] ?? value['content'];
+        if (nested is String && nested.trim().isNotEmpty) {
+          return nested;
+        }
+      }
+    }
+    return rawBody;
+  }
+
+  void _setError(String? message) {
+    _errorMessage = message;
+    notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    _statusResetTimer?.cancel();
+    _sessionTagDebounce?.cancel();
+    super.dispose();
+  }
+}

--- a/lib/Services/mindworks_service.dart
+++ b/lib/Services/mindworks_service.dart
@@ -1,0 +1,43 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+/// Basic REST client for communicating with MindWorks agents.
+///
+/// The [baseUrl] should point to the MindWorks API gateway or agent
+/// host. Individual agents are addressed via the `agent` field in the
+/// request body, allowing different backends to be selected at runtime.
+class MindWorksService {
+  MindWorksService({http.Client? client, this.baseUrl = 'http://192.168.1.150:8000/api'})
+      : _client = client ?? http.Client();
+
+  final http.Client _client;
+
+  /// Base URL for all requests. Can be changed via user settings.
+  String baseUrl;
+
+  /// Sends a prompt to the MindWorks backend and returns the decoded JSON.
+  Future<Map<String, dynamic>> sendPrompt({
+    required String agent,
+    required String prompt,
+    String? persona,
+    bool logToMemory = false,
+  }) async {
+    final response = await _client.post(
+      Uri.parse(baseUrl),
+      headers: const {'Content-Type': 'application/json'},
+      body: jsonEncode({
+        'agent': agent,
+        'persona': persona,
+        'prompt': prompt,
+        'log_to_memory': logToMemory,
+      }),
+    );
+
+    if (response.statusCode != 200) {
+      throw http.ClientException('Request failed: ${response.statusCode}');
+    }
+
+    return jsonDecode(response.body) as Map<String, dynamic>;
+  }
+}

--- a/lib/Services/mindworks_service.dart
+++ b/lib/Services/mindworks_service.dart
@@ -17,27 +17,82 @@ class MindWorksService {
   String baseUrl;
 
   /// Sends a prompt to the MindWorks backend and returns the decoded JSON.
-  Future<Map<String, dynamic>> sendPrompt({
+  Future<MindWorksApiResult> sendPrompt({
     required String agent,
     required String prompt,
     String? persona,
     bool logToMemory = false,
+    String? sessionTag,
   }) async {
-    final response = await _client.post(
-      Uri.parse(baseUrl),
-      headers: const {'Content-Type': 'application/json'},
-      body: jsonEncode({
-        'agent': agent,
-        'persona': persona,
-        'prompt': prompt,
-        'log_to_memory': logToMemory,
-      }),
-    );
+    final uri = Uri.parse(baseUrl);
+    final payload = <String, dynamic>{
+      'agent': agent,
+      'prompt': prompt,
+      'log_to_memory': logToMemory,
+    };
 
-    if (response.statusCode != 200) {
-      throw http.ClientException('Request failed: ${response.statusCode}');
+    if (persona != null && persona.isNotEmpty) {
+      payload['persona'] = persona;
     }
 
-    return jsonDecode(response.body) as Map<String, dynamic>;
+    if (sessionTag != null && sessionTag.isNotEmpty) {
+      payload['session_tag'] = sessionTag;
+    }
+
+    final stopwatch = Stopwatch()..start();
+    final response = await _client.post(
+      uri,
+      headers: const {'Content-Type': 'application/json'},
+      body: jsonEncode(payload),
+    );
+    stopwatch.stop();
+
+    final rawBody = response.body;
+    Map<String, dynamic> decodedBody;
+    try {
+      decodedBody = jsonDecode(rawBody) as Map<String, dynamic>;
+    } catch (_) {
+      decodedBody = <String, dynamic>{'raw': rawBody};
+    }
+
+    final result = MindWorksApiResult(
+      body: decodedBody,
+      rawBody: rawBody,
+      statusCode: response.statusCode,
+      duration: stopwatch.elapsed,
+    );
+
+    if (response.statusCode >= 200 && response.statusCode < 300) {
+      return result;
+    }
+
+    throw MindWorksApiException(
+      message: 'Request failed with status ${response.statusCode}',
+      result: result,
+    );
   }
+}
+
+class MindWorksApiResult {
+  MindWorksApiResult({
+    required this.body,
+    required this.rawBody,
+    required this.statusCode,
+    required this.duration,
+  });
+
+  final Map<String, dynamic> body;
+  final String rawBody;
+  final int statusCode;
+  final Duration duration;
+}
+
+class MindWorksApiException implements Exception {
+  MindWorksApiException({this.message, required this.result});
+
+  final String? message;
+  final MindWorksApiResult result;
+
+  @override
+  String toString() => message ?? 'MindWorksApiException(${result.statusCode})';
 }

--- a/lib/Widgets/agent_selector.dart
+++ b/lib/Widgets/agent_selector.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:reins/Providers/agent_provider.dart';
+
+/// Dropdown widget allowing users to select the active MindWorks agent.
+class AgentSelector extends StatelessWidget {
+  const AgentSelector({super.key, required this.agents});
+
+  final List<String> agents;
+
+  @override
+  Widget build(BuildContext context) {
+    final provider = context.watch<AgentProvider>();
+    return DropdownButton<String>(
+      value: provider.selectedAgent,
+      items: [
+        for (final agent in agents)
+          DropdownMenuItem(value: agent, child: Text(agent)),
+      ],
+      onChanged: (value) {
+        if (value != null) {
+          context.read<AgentProvider>().selectAgent(value);
+        }
+      },
+    );
+  }
+}

--- a/lib/Widgets/agent_selector.dart
+++ b/lib/Widgets/agent_selector.dart
@@ -11,10 +11,13 @@ class AgentSelector extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final provider = context.watch<AgentProvider>();
+    final options = <String>{...agents, provider.selectedAgent}.toList();
+    options.remove(provider.selectedAgent);
+    options.insert(0, provider.selectedAgent);
     return DropdownButton<String>(
       value: provider.selectedAgent,
       items: [
-        for (final agent in agents)
+        for (final agent in options)
           DropdownMenuItem(value: agent, child: Text(agent)),
       ],
       onChanged: (value) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,8 +5,10 @@ import 'package:reins/Models/settings_route_arguments.dart';
 import 'package:reins/Pages/main_page.dart';
 import 'package:reins/Pages/settings_page/settings_page.dart';
 import 'package:reins/Providers/chat_provider.dart';
+import 'package:reins/Providers/agent_provider.dart';
 import 'package:reins/Services/database_service.dart';
 import 'package:reins/Services/ollama_service.dart';
+import 'package:reins/Services/mindworks_service.dart';
 import 'package:reins/Utils/material_color_adapter.dart';
 import 'package:provider/provider.dart';
 import 'package:hive_flutter/hive_flutter.dart';
@@ -48,8 +50,10 @@ void main() async {
   runApp(
     MultiProvider(
       providers: [
+        Provider(create: (_) => MindWorksService()),
         Provider(create: (_) => OllamaService()),
         Provider(create: (_) => DatabaseService()),
+        ChangeNotifierProvider(create: (_) => AgentProvider()),
         ChangeNotifierProvider(
           create: (context) => ChatProvider(
             ollamaService: context.read(),
@@ -57,13 +61,13 @@ void main() async {
           ),
         ),
       ],
-      child: const ReinsApp(),
+      child: const MindWorksApp(),
     ),
   );
 }
 
-class ReinsApp extends StatelessWidget {
-  const ReinsApp({super.key});
+class MindWorksApp extends StatelessWidget {
+  const MindWorksApp({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -95,7 +99,7 @@ class ReinsApp extends StatelessWidget {
           onGenerateRoute: (settings) {
             if (settings.name == '/') {
               return MaterialPageRoute(
-                builder: (context) => const ReinsMainPage(),
+                builder: (context) => const MindWorksMainPage(),
               );
             }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,10 +4,8 @@ import 'package:reins/Constants/constants.dart';
 import 'package:reins/Models/settings_route_arguments.dart';
 import 'package:reins/Pages/main_page.dart';
 import 'package:reins/Pages/settings_page/settings_page.dart';
-import 'package:reins/Providers/chat_provider.dart';
 import 'package:reins/Providers/agent_provider.dart';
-import 'package:reins/Services/database_service.dart';
-import 'package:reins/Services/ollama_service.dart';
+import 'package:reins/Providers/mindworks_chat_provider.dart';
 import 'package:reins/Services/mindworks_service.dart';
 import 'package:reins/Utils/material_color_adapter.dart';
 import 'package:provider/provider.dart';
@@ -51,13 +49,11 @@ void main() async {
     MultiProvider(
       providers: [
         Provider(create: (_) => MindWorksService()),
-        Provider(create: (_) => OllamaService()),
-        Provider(create: (_) => DatabaseService()),
         ChangeNotifierProvider(create: (_) => AgentProvider()),
         ChangeNotifierProvider(
-          create: (context) => ChatProvider(
-            ollamaService: context.read(),
-            databaseService: context.read(),
+          create: (context) => MindWorksChatProvider(
+            service: context.read<MindWorksService>(),
+            agentProvider: context.read<AgentProvider>(),
           ),
         ),
       ],


### PR DESCRIPTION
## Summary
- rebrand to MindWorks Mobile and expose configurable agent-selection state
- introduce MindWorksService for REST calls with agent, persona and memory flags
- add AgentSelector widget for choosing active agent

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba5e5af3ac832882c312b57944441a